### PR TITLE
Add Hyperverse as soft dependency

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${project.version}
 main: io.josemmo.bukkit.plugin.YamipaPlugin
 api-version: 1.13
 depend: [ProtocolLib]
-softdepend: [Multiverse-Core]
+softdepend: [Multiverse-Core, Hyperverse]
 
 permissions:
   yamipa.*:


### PR DESCRIPTION
This allows maps in Hyperverse worlds to load when using it as a world manager.