### PR TITLE
Subfolder support for images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/josemmo/bukkit/plugin/commands/arguments/ImageFileArgument.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/commands/arguments/ImageFileArgument.java
@@ -39,7 +39,7 @@ public class ImageFileArgument extends StringArgument {
         @NotNull SuggestionsBuilder builder
     ) {
         for (String filename : YamipaPlugin.getInstance().getStorage().getAllFilenames()) {
-            builder.suggest(filename);
+            builder.suggest("\"" + filename.replace("\\", "/") + "\"");
         }
         return builder.buildFuture();
     }

--- a/src/main/java/io/josemmo/bukkit/plugin/storage/ImageFile.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/storage/ImageFile.java
@@ -241,7 +241,7 @@ public class ImageFile {
         }
 
         // Try to get maps from disk cache
-        String cacheFilename = name + "." + cacheKey + "." + CACHE_EXT;
+        String cacheFilename = name.replace("\\", "_") + "." + cacheKey + "." + CACHE_EXT;
         File cacheFile = Paths.get(plugin.getStorage().getCachePath(), cacheFilename).toFile();
         if (cacheFile.isFile() && cacheFile.lastModified() >= getLastModified()) {
             try {

--- a/src/main/java/io/josemmo/bukkit/plugin/storage/ImageFile.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/storage/ImageFile.java
@@ -416,7 +416,7 @@ public class ImageFile {
 
         // Delete disk cache files
         File[] files = Paths.get(plugin.getStorage().getCachePath()).toFile().listFiles((__, filename) -> {
-            return filename.matches(Pattern.quote(name) + "\\.[0-9]+-[0-9]+\\." + CACHE_EXT);
+            return filename.matches(Pattern.quote(name.replace("\\", "_")) + "\\.[0-9]+-[0-9]+\\." + CACHE_EXT);
         });
         if (files == null) {
             plugin.warning("An error occurred when listing cache files for image \"" + name + "\"");

--- a/src/main/java/io/josemmo/bukkit/plugin/storage/ImageStorage.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/storage/ImageStorage.java
@@ -76,12 +76,10 @@ public class ImageStorage {
         registerDir(directory.toPath(), watchService);
 
         // Start watching for changes
-        final boolean[] running = {true};
         task = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> {
-            while(running[0]) {
+            while(true) {
                 WatchKey watchKey = watchService.poll(); // Parse all happened events
                 if (watchKey == null)  { // Stop if no events are present
-                    running[0] = false;
                     return;
                 }
 
@@ -89,10 +87,9 @@ public class ImageStorage {
                     WatchEvent.Kind<?> kind = event.kind();
                     File file = keyPathMap.get(watchKey).resolve((Path) event.context()).toFile();
 
-
                     String filename = keyPathMap.get(watchKey).toString()
-                        .replace("plugins\\Yamipa\\images\\", "")
-                        .replace("plugins\\Yamipa\\images", "") + "\\" + file.getName();
+                        .replace(basePath + "\\", "")
+                        .replace(basePath, "") + "\\" + file.getName();
                     if (filename.startsWith("\\")) filename = filename.substring(1);
 
                     synchronized (this) {
@@ -107,7 +104,6 @@ public class ImageStorage {
                             if (imageFile != null) {
                                 imageFile.invalidate();
                                 cachedImages.remove(filename);
-                                System.out.println("Removed images");
                             }
                             plugin.fine("Detected file deletion at " + filename);
                         } else if (cachedImages.containsKey(filename)) {


### PR DESCRIPTION
### What is this Pr
This pr adds support for subfolders for images in the images folder. This can be important if you are working on a large server with many different images, as it makes sorting and keeping track of the images much easier. 
I have also read your response to this feature posted at https://github.com/josemmo/yamipa/issues/28#issuecomment-1020464674. 

### Adressing your concerns regarding performance and potential vulnerabilities
#### Performance
Yes, this function theoretically degrades the performance of the server. In my opinion, this is negligible, since the only real impact on the startup process is when reading the images from the folders. Let's consider a realistic example: a server with about 300 images and 50 folders. The impact of retrieving the files in those 50 folders is probably much less than the impact of reading a single image file. 
Monitoring file events in these additional folders does not really affect performance, since java.nio's WatchService only receives the events from the file system and does not actually look for file changes by itself. (See [WatchService](https://docs.oracle.com/javase/8/docs/api/java/nio/file/WatchService.html))

#### Potential path traversal vulnerabilities
These are not present because the user input is not actually used to retrieve and read the file. Rather, the inputted string is only used to retrieve the cached ImageFile that is created in the `cachedImages` map of the ImageStorage class at startup. Therefore, any user input is automatically filtered to be one of the valid paths for image files, leaving no opportunity for vulnerabilities. 

### What is this Pr not
This version does not support individual player image folders. Placing images, etc. still works as usual, but the actual image files can be placed in subfolders of the image folder. 