### PR TITLE
WrappedDataWatcher may require lazy initialization as of ProtocolLib 5.3.0.

### DIFF
--- a/src/main/java/io/josemmo/bukkit/plugin/packets/EntityMetadataPacket.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/packets/EntityMetadataPacket.java
@@ -9,6 +9,7 @@ import io.josemmo.bukkit.plugin.utils.Internals;
 import org.bukkit.Rotation;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ public class EntityMetadataPacket extends PacketContainer {
     private static final boolean USE_DATA_WATCHER;
     private static final int ITEM_INDEX;
     private static final int ROTATION_INDEX;
-    private WrappedDataWatcher dataWatcher; // For <= 1.19.2 - lazy initialization
+    private @Nullable WrappedDataWatcher dataWatcher; // For <= 1.19.2
     private final List<WrappedDataValue> values = new ArrayList<>(); // For >= 1.19.3
 
     static {
@@ -37,9 +38,12 @@ public class EntityMetadataPacket extends PacketContainer {
     }
 
     /**
-     * Get or create WrappedDataWatcher instance safely
+     * Get or create data watcher
+     * <p>
+     * Needed to avoid race condition in ProtocolLib, see <a href="https://github.com/josemmo/yamipa/pull/153">#153</a>
+     * @return Data watcher instance
      */
-    private WrappedDataWatcher getDataWatcher() {
+    private @NotNull WrappedDataWatcher getDataWatcher() {
         if (dataWatcher == null) {
             dataWatcher = new WrappedDataWatcher();
         }

--- a/src/main/java/io/josemmo/bukkit/plugin/packets/EntityMetadataPacket.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/packets/EntityMetadataPacket.java
@@ -17,7 +17,7 @@ public class EntityMetadataPacket extends PacketContainer {
     private static final boolean USE_DATA_WATCHER;
     private static final int ITEM_INDEX;
     private static final int ROTATION_INDEX;
-    private final WrappedDataWatcher dataWatcher = new WrappedDataWatcher(); // For <= 1.19.2
+    private WrappedDataWatcher dataWatcher; // For <= 1.19.2 - lazy initialization
     private final List<WrappedDataValue> values = new ArrayList<>(); // For >= 1.19.3
 
     static {
@@ -36,6 +36,16 @@ public class EntityMetadataPacket extends PacketContainer {
         super(PacketType.Play.Server.ENTITY_METADATA);
     }
 
+    /**
+     * Get or create WrappedDataWatcher instance safely
+     */
+    private WrappedDataWatcher getDataWatcher() {
+        if (dataWatcher == null) {
+            dataWatcher = new WrappedDataWatcher();
+        }
+        return dataWatcher;
+    }
+
     public @NotNull EntityMetadataPacket setId(int id) {
         getIntegers().write(0, id);
         return this;
@@ -44,7 +54,7 @@ public class EntityMetadataPacket extends PacketContainer {
     public @NotNull EntityMetadataPacket setFlags(byte flags) {
         WrappedDataWatcher.Serializer serializer = WrappedDataWatcher.Registry.get((Type) Byte.class);
         if (USE_DATA_WATCHER) {
-            dataWatcher.setObject(new WrappedDataWatcher.WrappedDataWatcherObject(0, serializer), flags);
+            getDataWatcher().setObject(new WrappedDataWatcher.WrappedDataWatcherObject(0, serializer), flags);
         } else {
             values.add(new WrappedDataValue(0, serializer, flags));
         }
@@ -59,7 +69,7 @@ public class EntityMetadataPacket extends PacketContainer {
     public @NotNull EntityMetadataPacket setItem(@NotNull ItemStack item) {
         WrappedDataWatcher.Serializer serializer = WrappedDataWatcher.Registry.getItemStackSerializer(false);
         if (USE_DATA_WATCHER) {
-            dataWatcher.setObject(new WrappedDataWatcher.WrappedDataWatcherObject(ITEM_INDEX, serializer), item);
+            getDataWatcher().setObject(new WrappedDataWatcher.WrappedDataWatcherObject(ITEM_INDEX, serializer), item);
         } else {
             values.add(new WrappedDataValue(
                 ITEM_INDEX,
@@ -73,7 +83,7 @@ public class EntityMetadataPacket extends PacketContainer {
     public @NotNull EntityMetadataPacket setRotation(@NotNull Rotation rotation) {
         WrappedDataWatcher.Serializer serializer = WrappedDataWatcher.Registry.get((Type) Integer.class);
         if (USE_DATA_WATCHER) {
-            dataWatcher.setObject(
+            getDataWatcher().setObject(
                 new WrappedDataWatcher.WrappedDataWatcherObject(ROTATION_INDEX, serializer),
                 rotation.ordinal()
             );
@@ -85,7 +95,7 @@ public class EntityMetadataPacket extends PacketContainer {
 
     public @NotNull EntityMetadataPacket build() {
         if (USE_DATA_WATCHER) {
-            getWatchableCollectionModifier().write(0, dataWatcher.getWatchableObjects());
+            getWatchableCollectionModifier().write(0, getDataWatcher().getWatchableObjects());
         } else {
             getDataValueCollectionModifier().write(0, values);
         }


### PR DESCRIPTION
Fixed a compatibility issue where images could not be displayed in Minecraft 1.19.4.

Changes in ProtocolLib 5.3.0
1. Changes to the internal implementation of the constructor
In ProtocolLib 5.2.0, the default constructor of WrappedDataWatcher worked as follows:

```java
public WrappedDataWatcher() {
    // Internally calls the constructor for Minecraft's DataWatcher class.
    // Works fine even with a null argument.
}
```

But in ProtocolLib 5.3.0:

```java
public WrappedDataWatcher() {
    // Internally calls MethodHandleHelper.getConstructorAccessor()
    // If constructor is null at this point, NPE occurs in Preconditions.checkNotNull()
}
```

This is probably a change to improve ProtocolLib's performance.
