### PR TITLE
Fix Paper 26.1.2 version parsing

### DIFF
--- a/src/main/java/io/josemmo/bukkit/plugin/interaction/SelectFakeItemFrameListener.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/interaction/SelectFakeItemFrameListener.java
@@ -25,6 +25,7 @@ public abstract class SelectFakeItemFrameListener implements PacketListener {
     private static final int MAX_BLOCK_DISTANCE = 5;
     private static final Logger LOGGER = Logger.getLogger("SelectFakeItemFrameListener");
     private static boolean hasWarnedActionFallback = false;
+    private static boolean hasWarnedEntityIdFallback = false;
 
     /**
      * Get fake image instance for player
@@ -93,25 +94,29 @@ public abstract class SelectFakeItemFrameListener implements PacketListener {
 
     @Override
     public final void onPacketReceiving(@NotNull PacketEvent event) {
+        Player player = event.getPlayer();
+
         // Ignore events for "real" in-game entities
-        int entityId = event.getPacket().getIntegers().read(0);
-        if (entityId < FakeItemFrame.MIN_FRAME_ID) {
+        Integer entityId = getEntityId(event);
+        if (entityId != null && entityId < FakeItemFrame.MIN_FRAME_ID) {
+            return;
+        }
+
+        // When entity ID cannot be read (protocol wrapper drift), only continue
+        // if player is actually aiming at one of our fake images.
+        if (entityId == null && getFakeImage(player) == null) {
             return;
         }
 
         // Get action
         EnumWrappers.EntityUseAction action = getEntityUseAction(event);
-        if (action == null) {
-            return;
-        }
 
         // Handle event
         boolean allowEvent = true;
-        Player player =  event.getPlayer();
         if (action == EnumWrappers.EntityUseAction.ATTACK) {
-            allowEvent = onLeftClick(player, entityId);
+            allowEvent = onLeftClick(player, (entityId != null) ? entityId : -1);
         } else if (action == EnumWrappers.EntityUseAction.INTERACT_AT || action == EnumWrappers.EntityUseAction.INTERACT) {
-            allowEvent = onRightClick(player, entityId);
+            allowEvent = onRightClick(player, (entityId != null) ? entityId : -1);
         }
 
         // Cancel event (if needed)
@@ -143,23 +148,70 @@ public abstract class SelectFakeItemFrameListener implements PacketListener {
         return YamipaPlugin.getInstance();
     }
 
-    private @Nullable EnumWrappers.EntityUseAction getEntityUseAction(@NotNull PacketEvent event) {
+    private @NotNull EnumWrappers.EntityUseAction getEntityUseAction(@NotNull PacketEvent event) {
         if (Internals.MINECRAFT_VERSION < 1700) {
-            return event.getPacket().getEntityUseActions().read(0);
-        }
-
-        try {
-            return event.getPacket().getEnumEntityUseActions().read(0).getAction();
-        } catch (Throwable primaryError) {
             try {
                 EnumWrappers.EntityUseAction action = event.getPacket().getEntityUseActions().read(0);
-                warnActionFallback("Failed to read USE_ENTITY action with enum wrapper, using fallback parser", primaryError);
-                return action;
-            } catch (Throwable fallbackError) {
-                warnActionFallback("Failed to read USE_ENTITY action from packet", fallbackError);
-                return null;
+                if (action != null) {
+                    return action;
+                }
+            } catch (Throwable __) {
+                // Continue with fallback parser
             }
+
+            warnActionFallback("Failed to parse legacy USE_ENTITY action directly, using inferred action");
+            return inferEntityUseAction(event);
         }
+
+        Throwable primaryError = null;
+        try {
+            // Prefer this accessor first: it's the most stable across ProtocolLib versions.
+            EnumWrappers.EntityUseAction action = event.getPacket().getEntityUseActions().read(0);
+            if (action != null) {
+                return action;
+            }
+        } catch (Throwable e) {
+            primaryError = e;
+        }
+
+        EnumWrappers.EntityUseAction inferredAction = inferEntityUseAction(event);
+        if (primaryError != null) {
+            warnActionFallback("Failed to parse USE_ENTITY action directly, using inferred action", primaryError);
+        }
+        return inferredAction;
+    }
+
+    private @Nullable Integer getEntityId(@NotNull PacketEvent event) {
+        try {
+            // Modern versions expose the target entity as a VarInt in this modifier.
+            return event.getPacket().getIntegers().read(0);
+        } catch (Throwable e) {
+            warnEntityIdFallback("Failed to read USE_ENTITY target entity ID from packet", e);
+            return null;
+        }
+    }
+
+    private @NotNull EnumWrappers.EntityUseAction inferEntityUseAction(@NotNull PacketEvent event) {
+        // 1) ATTACK packets do not carry a hand value
+        try {
+            if (event.getPacket().getHands().readSafely(0) == null) {
+                return EnumWrappers.EntityUseAction.ATTACK;
+            }
+        } catch (Throwable __) {
+            // Ignore and continue with the next heuristic
+        }
+
+        // 2) INTERACT_AT carries a target position vector
+        try {
+            if (event.getPacket().getVectors().readSafely(0) != null) {
+                return EnumWrappers.EntityUseAction.INTERACT_AT;
+            }
+        } catch (Throwable __) {
+            // Ignore and continue with the next heuristic
+        }
+
+        // 3) Remaining handled interactions are treated as INTERACT
+        return EnumWrappers.EntityUseAction.INTERACT;
     }
 
     private void warnActionFallback(@NotNull String message, @NotNull Throwable e) {
@@ -168,4 +220,19 @@ public abstract class SelectFakeItemFrameListener implements PacketListener {
             LOGGER.warning(message, e);
         }
     }
+
+    private void warnActionFallback(@NotNull String message) {
+        if (!hasWarnedActionFallback) {
+            hasWarnedActionFallback = true;
+            LOGGER.warning(message);
+        }
+    }
+
+    private void warnEntityIdFallback(@NotNull String message, @NotNull Throwable e) {
+        if (!hasWarnedEntityIdFallback) {
+            hasWarnedEntityIdFallback = true;
+            LOGGER.warning(message, e);
+        }
+    }
+
 }

--- a/src/main/java/io/josemmo/bukkit/plugin/interaction/SelectFakeItemFrameListener.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/interaction/SelectFakeItemFrameListener.java
@@ -12,6 +12,7 @@ import io.josemmo.bukkit.plugin.renderer.FakeImage;
 import io.josemmo.bukkit.plugin.renderer.FakeItemFrame;
 import io.josemmo.bukkit.plugin.renderer.ImageRenderer;
 import io.josemmo.bukkit.plugin.utils.Internals;
+import io.josemmo.bukkit.plugin.utils.Logger;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
@@ -22,6 +23,8 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class SelectFakeItemFrameListener implements PacketListener {
     private static final int MAX_BLOCK_DISTANCE = 5;
+    private static final Logger LOGGER = Logger.getLogger("SelectFakeItemFrameListener");
+    private static boolean hasWarnedActionFallback = false;
 
     /**
      * Get fake image instance for player
@@ -97,11 +100,9 @@ public abstract class SelectFakeItemFrameListener implements PacketListener {
         }
 
         // Get action
-        EnumWrappers.EntityUseAction action;
-        if (Internals.MINECRAFT_VERSION < 1700) {
-            action = event.getPacket().getEntityUseActions().read(0);
-        } else {
-            action = event.getPacket().getEnumEntityUseActions().read(0).getAction();
+        EnumWrappers.EntityUseAction action = getEntityUseAction(event);
+        if (action == null) {
+            return;
         }
 
         // Handle event
@@ -109,7 +110,7 @@ public abstract class SelectFakeItemFrameListener implements PacketListener {
         Player player =  event.getPlayer();
         if (action == EnumWrappers.EntityUseAction.ATTACK) {
             allowEvent = onLeftClick(player, entityId);
-        } else if (action == EnumWrappers.EntityUseAction.INTERACT_AT) {
+        } else if (action == EnumWrappers.EntityUseAction.INTERACT_AT || action == EnumWrappers.EntityUseAction.INTERACT) {
             allowEvent = onRightClick(player, entityId);
         }
 
@@ -140,5 +141,31 @@ public abstract class SelectFakeItemFrameListener implements PacketListener {
     @Override
     public final @NotNull Plugin getPlugin() {
         return YamipaPlugin.getInstance();
+    }
+
+    private @Nullable EnumWrappers.EntityUseAction getEntityUseAction(@NotNull PacketEvent event) {
+        if (Internals.MINECRAFT_VERSION < 1700) {
+            return event.getPacket().getEntityUseActions().read(0);
+        }
+
+        try {
+            return event.getPacket().getEnumEntityUseActions().read(0).getAction();
+        } catch (Throwable primaryError) {
+            try {
+                EnumWrappers.EntityUseAction action = event.getPacket().getEntityUseActions().read(0);
+                warnActionFallback("Failed to read USE_ENTITY action with enum wrapper, using fallback parser", primaryError);
+                return action;
+            } catch (Throwable fallbackError) {
+                warnActionFallback("Failed to read USE_ENTITY action from packet", fallbackError);
+                return null;
+            }
+        }
+    }
+
+    private void warnActionFallback(@NotNull String message, @NotNull Throwable e) {
+        if (!hasWarnedActionFallback) {
+            hasWarnedActionFallback = true;
+            LOGGER.warning(message, e);
+        }
     }
 }

--- a/src/main/java/io/josemmo/bukkit/plugin/renderer/ItemService.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/renderer/ItemService.java
@@ -195,6 +195,13 @@ public class ItemService extends SelectFakeItemFrameListener implements Listener
     @Override
     @SuppressWarnings("deprecation")
     protected boolean onLeftClick(@NotNull Player player, int entityId) {
+        // Attack path intentionally ignored on modern versions where USE_ENTITY attack is unreliable.
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected boolean onRightClick(@NotNull Player player, int entityId) {
         YamipaPlugin.getInstance().getScheduler().runInGame(() -> {
             // Get image selected by player
             FakeImage image = SelectFakeItemFrameListener.getFakeImage(player);
@@ -203,8 +210,9 @@ public class ItemService extends SelectFakeItemFrameListener implements Listener
                 return;
             }
 
-            // Silently ignore non-removable images
+            // Ignore non-removable images
             if (!image.hasFlag(FakeImage.FLAG_REMOVABLE)) {
+                ActionBar.send(player, ChatColor.RED + "This image cannot be removed");
                 return;
             }
 
@@ -228,7 +236,7 @@ public class ItemService extends SelectFakeItemFrameListener implements Listener
             }
 
             // Drop image item in front of player
-            if (player.getGameMode() == GameMode.SURVIVAL && image.hasFlag(FakeImage.FLAG_DROPPABLE)) {
+            if (player.getGameMode() != GameMode.CREATIVE && image.hasFlag(FakeImage.FLAG_DROPPABLE)) {
                 ImageFile imageFile = Objects.requireNonNull(image.getFile());
                 ItemStack imageItem = getImageItem(imageFile, 1, image.getWidth(), image.getHeight(), image.getFlags());
                 Location dropLocation = player.getEyeLocation().add(player.getLocation().getDirection().normalize());
@@ -236,12 +244,6 @@ public class ItemService extends SelectFakeItemFrameListener implements Listener
             }
         }, player.getLocation(), 0);
         return false;
-    }
-
-    @Override
-    protected boolean onRightClick(@NotNull Player player, int entityId) {
-        // Intentionally left blank
-        return true;
     }
 
     @Override

--- a/src/main/java/io/josemmo/bukkit/plugin/utils/Internals.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/utils/Internals.java
@@ -2,6 +2,8 @@ package io.josemmo.bukkit.plugin.utils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.command.CommandMap;
@@ -13,13 +15,16 @@ import com.comphenix.protocol.utility.MinecraftReflection;
 import com.mojang.brigadier.CommandDispatcher;
 
 public class Internals {
+    private static final Pattern MC_VERSION_PATTERN = Pattern.compile("\\(MC: ([0-9]+(?:\\.[0-9]+){1,2})\\)");
+
     /**
-     * Minecraft version in the form of mmpp (mm is 2-digit minor, pp is 2-digit patch), major number is always ignored.
+     * Minecraft version in the form of mmpp (mm is the compatibility major, pp is the compatibility patch).
      * <p>
      * Examples:
      * <li> "1.16" becomes 1600
      * <li> "1.20.3" becomes 2003
      * <li> "1.21.10" becomes 2110
+     * <li> "26.1.2" becomes 2601
      * */
     public static final int MINECRAFT_VERSION;
     public static final boolean IS_FOLIA;
@@ -30,11 +35,7 @@ public class Internals {
     static {
         try {
             // Get Minecraft version
-            String rawVersion = Bukkit.getVersion();
-            String version = rawVersion.substring(rawVersion.lastIndexOf("(MC: 1.")+7, rawVersion.length()-1);
-            String minorNumber = version.contains(".") ? version.substring(0, version.indexOf(".")) : version;
-            String patchNumber = version.contains(".") ? version.substring(version.indexOf(".")+1) : "0";
-            MINECRAFT_VERSION = Integer.parseInt(minorNumber) * 100 + Integer.parseInt(patchNumber);
+            MINECRAFT_VERSION = parseMinecraftVersion(Bukkit.getVersion());
 
             // Detect Folia
             boolean isFolia;
@@ -75,6 +76,29 @@ public class Internals {
         } catch (Exception e) {
             throw new RuntimeException("Failed to get internal classes due to incompatible Minecraft server", e);
         }
+    }
+
+    private static int parseMinecraftVersion(@NotNull String rawVersion) {
+        Matcher matcher = MC_VERSION_PATTERN.matcher(rawVersion);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("Could not parse Minecraft version from: " + rawVersion);
+        }
+
+        String[] parts = matcher.group(1).split("\\.");
+        if (parts.length < 2) {
+            throw new IllegalArgumentException("Invalid Minecraft version format: " + matcher.group(1));
+        }
+
+        int major = Integer.parseInt(parts[0]);
+        int minor = Integer.parseInt(parts[1]);
+        int patch = (parts.length >= 3) ? Integer.parseInt(parts[2]) : 0;
+
+        // Legacy format was 1.x.y; new Paper builds may expose x.y.z.
+        // We keep returning mmpp so the existing compatibility checks remain valid.
+        if (major == 1) {
+            return minor * 100 + patch;
+        }
+        return major * 100 + minor;
     }
 
     /**

--- a/src/main/java/io/josemmo/bukkit/plugin/utils/Internals.java
+++ b/src/main/java/io/josemmo/bukkit/plugin/utils/Internals.java
@@ -16,6 +16,7 @@ import com.mojang.brigadier.CommandDispatcher;
 
 public class Internals {
     private static final Pattern MC_VERSION_PATTERN = Pattern.compile("\\(MC: ([0-9]+(?:\\.[0-9]+){1,2})\\)");
+    private static final Pattern NUMERIC_VERSION_PATTERN = Pattern.compile("^[0-9]+(?:\\.[0-9]+){1,2}$");
 
     /**
      * Minecraft version in the form of mmpp (mm is the compatibility major, pp is the compatibility patch).
@@ -35,7 +36,7 @@ public class Internals {
     static {
         try {
             // Get Minecraft version
-            MINECRAFT_VERSION = parseMinecraftVersion(Bukkit.getVersion());
+            MINECRAFT_VERSION = parseMinecraftVersion(getMinecraftVersion());
 
             // Detect Folia
             boolean isFolia;
@@ -78,15 +79,30 @@ public class Internals {
         }
     }
 
-    private static int parseMinecraftVersion(@NotNull String rawVersion) {
-        Matcher matcher = MC_VERSION_PATTERN.matcher(rawVersion);
-        if (!matcher.find()) {
-            throw new IllegalArgumentException("Could not parse Minecraft version from: " + rawVersion);
+    private static @NotNull String getMinecraftVersion() {
+        try {
+            // Prefer stable API when available (Paper/modern Bukkit)
+            Method getMinecraftVersionMethod = Bukkit.getServer().getClass().getMethod("getMinecraftVersion");
+            Object version = getMinecraftVersionMethod.invoke(Bukkit.getServer());
+            if (version instanceof String && NUMERIC_VERSION_PATTERN.matcher((String) version).matches()) {
+                return (String) version;
+            }
+        } catch (Exception __) {
+            // Fallback to parsing Bukkit.getVersion() on older server APIs
         }
 
-        String[] parts = matcher.group(1).split("\\.");
+        String rawVersion = Bukkit.getVersion();
+        Matcher matcher = MC_VERSION_PATTERN.matcher(rawVersion);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        throw new IllegalArgumentException("Could not parse Minecraft version from: " + rawVersion);
+    }
+
+    private static int parseMinecraftVersion(@NotNull String version) {
+        String[] parts = version.split("\\.");
         if (parts.length < 2) {
-            throw new IllegalArgumentException("Invalid Minecraft version format: " + matcher.group(1));
+            throw new IllegalArgumentException("Invalid Minecraft version format: " + version);
         }
 
         int major = Integer.parseInt(parts[0]);


### PR DESCRIPTION
Adds compatibility for Paper 26.1.2 version parsing while keeping backward compatibility with previous server version formats.

Needs strong in-game testing before release.